### PR TITLE
fix(android): upgrade webrtc sdk version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,7 +130,7 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   api 'com.github.davidliu:audioswitch:c498d866c57f1d88056d5e7e7a78d622e3b0c046'
-  api 'io.github.webrtc-sdk:android:104.5112.09'
+  api 'io.github.webrtc-sdk:android:104.5112.10'
   implementation project(':livekit_react-native-webrtc')
   implementation "androidx.annotation:annotation:1.4.0"
 }


### PR DESCRIPTION
Android app fails to build since I installed 1.1.2.
WrappedVideoDecoderFactory class is added in 104.5112.10 but this library uses 104.5112.09 version, causing build error.