### PR TITLE
feat: allow users to use screensharing without manual setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@ Enabling screenshare requires extra installation steps:
 
 Android screenshare requires a foreground service with type `mediaProjection` to be present.
 
+From 2.4.0 onwards, this is handled internally and no extra setup is required.
+
+---
+
+On versions prior to 2.4.0, you must declare your own foreground service.
+
 The example app uses [@supersami/rn-foreground-service](https://github.com/Raja0sama/rn-foreground-service) for this.
 
 Add the following permissions to your `AndroidManifest.xml` file:

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -10,4 +10,6 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
 </manifest>

--- a/android/src/main/java/com/livekit/reactnative/LiveKitReactNative.kt
+++ b/android/src/main/java/com/livekit/reactnative/LiveKitReactNative.kt
@@ -30,10 +30,14 @@ object LiveKitReactNative {
      */
     @JvmStatic
     @JvmOverloads
-    fun setup(context: Context, audioType: AudioType = AudioType.CommunicationAudioType()) {
+    fun setup(
+        context: Context,
+        audioType: AudioType = AudioType.CommunicationAudioType()
+    ) {
         val options = WebRTCModuleOptions.getInstance()
         options.videoEncoderFactory = CustomVideoEncoderFactory(null, true, true)
         options.videoDecoderFactory = CustomVideoDecoderFactory()
+        options.enableMediaProjectionService = true
 
         val useHardwareAudioProcessing = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -9,8 +9,7 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
-
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"
@@ -40,7 +39,7 @@
         android:value=""
       />
       <service android:name="com.supersami.foregroundservice.ForegroundService"
-            android:foregroundServiceType="mediaProjection" />
+            android:foregroundServiceType="mediaPlayback" />
       <service android:name="com.supersami.foregroundservice.ForegroundServiceTask" />
       <service android:name="com.voximplant.foregroundservice.VIForegroundService"  />
     </application>


### PR DESCRIPTION
Note: This adds the FOREGROUND_SERVICE and FOREGROUND_SERVICE_MEDIA_PROJECTION permissions.

These are required for screensharing. If this functionality is not needed, you can remove the permissions by using `tools:node="remove" in your AndroidManifest.xml:
```
<manifest>
    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" tools:node="remove" />
    ...
```

https://developer.android.com/build/manage-manifests#merge_rule_markers