### PR TITLE
fix: use minSdkVersion set by client app

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   namespace "com.livekit.reactnative"
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 LivekitReactNative_kotlinVersion=1.6.10
 LivekitReactNative_compileSdkVersion=29
 LivekitReactNative_targetSdkVersion=29
+LivekitReactNative_minSdkVersion=16


### PR DESCRIPTION
Currently the library forces minSdkVersion to 16 which seems to cause issues with a consumer app. We should allow setting that externally.