### PR TITLE
fix: use _peerConnectionId for accurate volume tracking

### DIFF
--- a/src/hooks/useTrackVolume.ts
+++ b/src/hooks/useTrackVolume.ts
@@ -29,6 +29,7 @@ export function useTrackVolume(
 
   const mediaStreamTrack = track?.mediaStreamTrack;
   const hasMediaStreamTrack = mediaStreamTrack != null;
+  // @ts-ignore - Accessing private property
   const peerConnectionId = mediaStreamTrack._peerConnectionId ?? -1;
   const mediaStreamTrackId = mediaStreamTrack.id;
 

--- a/src/hooks/useTrackVolume.ts
+++ b/src/hooks/useTrackVolume.ts
@@ -7,6 +7,7 @@ import {
 import { useEffect, useState } from 'react';
 import { addListener, removeListener } from '../events/EventEmitter';
 import LiveKitModule from '../LKNativeModule';
+import type { MediaStreamTrack } from '@livekit/react-native-webrtc';
 
 /**
  * A hook for tracking the volume of an audio track.
@@ -27,11 +28,12 @@ export function useTrackVolume(
           trackOrTrackReference?.publication?.track
         );
 
-  const mediaStreamTrack = track?.mediaStreamTrack;
+  const mediaStreamTrack = track?.mediaStreamTrack as
+    | MediaStreamTrack
+    | undefined;
   const hasMediaStreamTrack = mediaStreamTrack != null;
-  // @ts-ignore - Accessing private property
-  const peerConnectionId = mediaStreamTrack._peerConnectionId ?? -1;
-  const mediaStreamTrackId = mediaStreamTrack.id;
+  const peerConnectionId = mediaStreamTrack?._peerConnectionId ?? -1;
+  const mediaStreamTrackId = mediaStreamTrack?.id;
 
   let [volume, setVolume] = useState(0.0);
   useEffect(() => {


### PR DESCRIPTION
The current implementation uses mediaStreamTrack.peerConnectionId, which is undefined in certain platforms. This PR fixes the issue by accessing the internal _peerConnectionId property. Though private, this is necessary for consistent behavior and avoids a silent failure in the volume processor. Tested and verified to resolve the issue.
Faced Issue :
https://livekit-users.slack.com/archives/C07FVFGAUKX/p1743737909092499
Now solved