### PR TITLE
iOS Audio configuration improvements

### DIFF
--- a/ios/AudioUtils.swift
+++ b/ios/AudioUtils.swift
@@ -6,7 +6,11 @@ public class AudioUtils {
         case "default_":
             .default
         case "voicePrompt":
-            .voicePrompt
+            if #available(iOS 12.0, *) {
+                .voicePrompt
+            } else {
+                .default
+            }
         case "videoRecording":
             .videoRecording
         case "videoChat":

--- a/ios/LivekitReactNativeModule.m
+++ b/ios/LivekitReactNativeModule.m
@@ -19,7 +19,9 @@ RCT_EXTERN_METHOD(selectAudioOutput:(NSString *)deviceId
 
 
 /// Configure audio config for WebRTC
-RCT_EXTERN_METHOD(setAppleAudioConfiguration:(NSDictionary *) configuration)
+RCT_EXTERN_METHOD(setAppleAudioConfiguration:(NSDictionary *)configuration
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(createAudioSinkListener:(nonnull NSNumber *)pcId
                                         trackId:(nonnull NSString *)trackId)


### PR DESCRIPTION
Configuring AVAudioSession can fail, especially during a phone call. To handle this, propagate the configuration failure so that getUserMedia() will throw before continuing with the audio stack.

[This PR](https://github.com/livekit/react-native-webrtc/pull/59) already includes checks at the WebRTC level to prevent crashes. However, without this PR, failures will likely occur silently, leaving the user unaware. With this PR, the error will be thrown explicitly.
