### PR TITLE
Fix incomplete exports map in package.json

### DIFF
--- a/.changeset/quiet-crews-cover.md
+++ b/.changeset/quiet-crews-cover.md
@@ -1,0 +1,5 @@
+---
+'@livekit/react-native': patch
+---
+
+Fix incomplete exports map in package.json, causing a dual-instance of @livekit/components and breaking RoomContext

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - 'release/**'   # e.g. release/2.10.x
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     ".": {
       "source": "./src/index.tsx",
       "types": "./lib/typescript/src/index.d.ts",
+      "react-native": "./src/index.tsx",
+      "import":  "./lib/module/index.js",
+      "require": "./lib/commonjs/index.js",
       "default": "./lib/commonjs/index.js"
     }
   },


### PR DESCRIPTION
This was causing a dual-instance of @livekit/components and breaking RoomContext. See #349 