### PR TITLE
Quality: Dangling reference expression in MediaRecorder shim

### DIFF
--- a/src/polyfills/MediaRecorderShim.ts
+++ b/src/polyfills/MediaRecorderShim.ts
@@ -9,7 +9,6 @@ function shimMediaRecorder() {
     // @ts-expect-error
     global.MediaRecorder = MediaRecorder
   }
-  MediaRecorder
 }
 
 shimMediaRecorder();


### PR DESCRIPTION
## Summary

Quality: Dangling reference expression in MediaRecorder shim

## Problem

**Severity**: `Low` | **File**: `src/polyfills/MediaRecorderShim.ts:L14`

The final statement 'MediaRecorder' in shimMediaRecorder does nothing and serves no purpose. It appears to be a leftover or mistaken attempt to ensure the module is loaded.

## Solution

Remove the dangling 'MediaRecorder' expression. The import already ensures the module is loaded.

## Changes

- `src/polyfills/MediaRecorderShim.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced